### PR TITLE
ci: disable Husky in release step (HUSKY=0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,6 @@ jobs:
           bun run | grep -q "^test" && bun run test || true
 
       - name: Release
+        env:
+          HUSKY: '0'
         run: bunx semantic-release


### PR DESCRIPTION
## Summary
Disable Husky during semantic-release commit so prepare step can commit generated files in CI.

## Why
Husky pre-commit was running `bun test` and failing due to no tests, blocking `@semantic-release/git`.

## Change
Set `HUSKY=0` env for the Release step only.