### PR TITLE
ci: enforce semantic PR titles on next

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,35 @@
+name: Semantic PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          subjectPattern: .+
+          subjectPatternError: >-
+            The subject may not be empty.
+            Please use Conventional Commits, e.g. "feat: add clearButtonMode to NitroTextInput".


### PR DESCRIPTION
Enforces Conventional Commit style PR titles so squash merges into `next` create releasable commit messages.

- Adds `amannn/action-semantic-pull-request` on `pull_request_target`
- Prevents non-semantic titles that cause `no release` on next