### PR TITLE
feat: add secureTextEntry support for iOS text input

### DIFF
--- a/.cursor/rules/subagents.mdc
+++ b/.cursor/rules/subagents.mdc
@@ -1,0 +1,12 @@
+---
+alwaysApply: true
+---
+
+ALWAYS spawn subagents by running `cursor-agent -p [task] --output-format=text --force --model [model]` in the terminal. Each subagent should return a summary of the changes it made. Subagents should be used for ALL tasks
+
+You can adopt a fan-out pattern where you spawn subagents to perform parallel isolated tasks, and then fan-in the results.
+
+Use the following models:
+
+- `--model gpt-5` for reasoning, researching, and planning
+- `--model sonnet-4` for implementation

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,8 +1,12 @@
 import { StatusBar } from 'expo-status-bar'
-import { Platform } from 'react-native'
-import { DynamicColorIOS, PlatformColor } from 'react-native'
-
-import { StyleSheet, TextInput, View } from 'react-native'
+import {
+  DynamicColorIOS,
+  Platform,
+  PlatformColor,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native'
 import { NitroTextInput } from 'react-native-nitro-text-input'
 
 export default function App() {
@@ -38,6 +42,7 @@ export default function App() {
               })
             : '#00f'
         }
+        secureTextEntry={false}
         style={{ width: '100%' }}
       />
       <TextInput

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -450,6 +450,25 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
+    var secureTextEntry: Bool? {
+        didSet {
+            Task { @MainActor in
+                guard let secure = self.secureTextEntry else {
+                    self.textField.isSecureTextEntry = false
+                    return
+                }
+                if self.textField.isSecureTextEntry != secure {
+                    self.textField.isSecureTextEntry = secure
+                    // Work around UIKit artifact by resetting attributedText, like RN
+                    let original = self.textField.attributedText?.copy() as? NSAttributedString
+                    self.textField.attributedText = NSAttributedString()
+                    if let original = original {
+                        self.textField.attributedText = original
+                    }
+                }
+            }
+        }
+    }
     // Accept numeric AARRGGBB (Double) or JSON stringified OpaqueColor (String)
     var placeholderTextColor: PlaceholderTextColor? {
         didSet {

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -453,19 +453,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
     var secureTextEntry: Bool? {
         didSet {
             Task { @MainActor in
-                guard let secure = self.secureTextEntry else {
-                    self.textField.isSecureTextEntry = false
-                    return
-                }
-                if self.textField.isSecureTextEntry != secure {
-                    self.textField.isSecureTextEntry = secure
-                    // Work around UIKit artifact by resetting attributedText, like RN
-                    let original = self.textField.attributedText?.copy() as? NSAttributedString
-                    self.textField.attributedText = NSAttributedString()
-                    if let original = original {
-                        self.textField.attributedText = original
-                    }
-                }
+                self.textField.isSecureTextEntry = self.secureTextEntry ?? false
             }
         }
     }
@@ -802,7 +790,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
         let color: UIColor? = {
             guard let value = self.placeholderTextColor else { return nil }
             // Accept either numeric (AARRGGBB) or stringified object from processColor
-            if case let .second(doubleValue) = value {
+            if case .second(let doubleValue) = value {
                 let v = UInt32(clamping: Int64(doubleValue))
                 let a = CGFloat((v >> 24) & 0xFF) / 255.0
                 let r = CGFloat((v >> 16) & 0xFF) / 255.0
@@ -811,7 +799,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
                 return UIColor(red: r, green: g, blue: b, alpha: a)
             }
             var parsedDict: [String: Any]? = nil
-            if case let .first(json) = value,
+            if case .first(let json) = value,
                 let data = json.data(using: .utf8),
                 let dict = try? JSONSerialization.jsonObject(with: data)
                     as? [String: Any]
@@ -964,16 +952,23 @@ extension HybridTextInputView {
         if let dict = value as? [String: Any] {
             parsedDict = dict
         } else if let json = value as? String,
-                  let data = json.data(using: .utf8),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let data = json.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data)
+                as? [String: Any]
+        {
             parsedDict = dict
         }
         if let dict = parsedDict {
-            if let semantic = dict["semantic"] as? [String], let name = semantic.first {
-                return UIColor(named: name) ?? UIColor.value(forKey: name) as? UIColor
+            if let semantic = dict["semantic"] as? [String],
+                let name = semantic.first
+            {
+                return UIColor(named: name) ?? UIColor.value(forKey: name)
+                    as? UIColor
             }
             if let dynamic = dict["dynamic"] as? [String: Any] {
-                let light = resolveColor(any: dynamic["light"]) ?? UIColor.placeholderText
+                let light =
+                    resolveColor(any: dynamic["light"])
+                    ?? UIColor.placeholderText
                 let dark = resolveColor(any: dynamic["dark"]) ?? light
                 if #available(iOS 13.0, *) {
                     return UIColor { traits in
@@ -987,4 +982,3 @@ extension HybridTextInputView {
         return nil
     }
 }
-

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -453,7 +453,16 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
     var secureTextEntry: Bool? {
         didSet {
             Task { @MainActor in
-                self.textField.isSecureTextEntry = self.secureTextEntry ?? false
+                let secure = self.secureTextEntry ?? false
+                let wasFirstResponder = self.textField.isFirstResponder
+                let previousSelection = self.textField.selectedTextRange
+                self.textField.isSecureTextEntry = secure
+                if wasFirstResponder {
+                    _ = self.textField.becomeFirstResponder()
+                    if let sel = previousSelection {
+                        self.textField.selectedTextRange = sel
+                    }
+                }
             }
         }
     }

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -453,16 +453,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
     var secureTextEntry: Bool? {
         didSet {
             Task { @MainActor in
-                let secure = self.secureTextEntry ?? false
-                let wasFirstResponder = self.textField.isFirstResponder
-                let previousSelection = self.textField.selectedTextRange
-                self.textField.isSecureTextEntry = secure
-                if wasFirstResponder {
-                    _ = self.textField.becomeFirstResponder()
-                    if let sel = previousSelection {
-                        self.textField.selectedTextRange = sel
-                    }
-                }
+                self.textField.isSecureTextEntry = self.secureTextEntry ?? false
             }
         }
     }

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -237,6 +237,15 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JPlaceholderTextColor> /* placeholderTextColor */)>("setPlaceholderTextColor");
     method(_javaPart, placeholderTextColor.has_value() ? JPlaceholderTextColor::fromCpp(placeholderTextColor.value()) : nullptr);
   }
+  std::optional<bool> JHybridNitroTextInputViewSpec::getSecureTextEntry() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getSecureTextEntry");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(static_cast<bool>(__result->value())) : std::nullopt;
+  }
+  void JHybridNitroTextInputViewSpec::setSecureTextEntry(std::optional<bool> secureTextEntry) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* secureTextEntry */)>("setSecureTextEntry");
+    method(_javaPart, secureTextEntry.has_value() ? jni::JBoolean::valueOf(secureTextEntry.value()) : nullptr);
+  }
   std::optional<std::function<void()>> JHybridNitroTextInputViewSpec::getOnFocused() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>()>("getOnFocused_cxx");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
@@ -87,6 +87,8 @@ namespace margelo::nitro::nitrotextinput {
     void setPlaceholder(const std::optional<std::string>& placeholder) override;
     std::optional<std::variant<std::string, double>> getPlaceholderTextColor() override;
     void setPlaceholderTextColor(const std::optional<std::variant<std::string, double>>& placeholderTextColor) override;
+    std::optional<bool> getSecureTextEntry() override;
+    void setSecureTextEntry(std::optional<bool> secureTextEntry) override;
     std::optional<std::function<void()>> getOnFocused() override;
     void setOnFocused(const std::optional<std::function<void()>>& onFocused) override;
     std::optional<std::function<void()>> getOnBlurred() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
@@ -112,6 +112,10 @@ void JHybridNitroTextInputViewStateUpdater::updateViewProps(jni::alias_ref<jni::
     view->setPlaceholderTextColor(props.placeholderTextColor.value);
     // TODO: Set isDirty = false
   }
+  if (props.secureTextEntry.isDirty) {
+    view->setSecureTextEntry(props.secureTextEntry.value);
+    // TODO: Set isDirty = false
+  }
   if (props.onFocused.isDirty) {
     view->setOnFocused(props.onFocused.value);
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
@@ -152,6 +152,12 @@ abstract class HybridNitroTextInputViewSpec: HybridView() {
   @set:Keep
   abstract var placeholderTextColor: PlaceholderTextColor?
   
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var secureTextEntry: Boolean?
+  
   abstract var onFocused: (() -> Unit)?
   
   private var onFocused_cxx: Func_void?

--- a/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
@@ -206,6 +206,13 @@ namespace margelo::nitro::nitrotextinput {
     inline void setPlaceholderTextColor(const std::optional<std::variant<std::string, double>>& placeholderTextColor) noexcept override {
       _swiftPart.setPlaceholderTextColor(placeholderTextColor);
     }
+    inline std::optional<bool> getSecureTextEntry() noexcept override {
+      auto __result = _swiftPart.getSecureTextEntry();
+      return __result;
+    }
+    inline void setSecureTextEntry(std::optional<bool> secureTextEntry) noexcept override {
+      _swiftPart.setSecureTextEntry(secureTextEntry);
+    }
     inline std::optional<std::function<void()>> getOnFocused() noexcept override {
       auto __result = _swiftPart.getOnFocused();
       return __result;

--- a/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
@@ -166,6 +166,11 @@ using namespace margelo::nitro::nitrotextinput::views;
     swiftPart.setPlaceholderTextColor(newViewProps.placeholderTextColor.value);
     newViewProps.placeholderTextColor.isDirty = false;
   }
+  // secureTextEntry: optional
+  if (newViewProps.secureTextEntry.isDirty) {
+    swiftPart.setSecureTextEntry(newViewProps.secureTextEntry.value);
+    newViewProps.secureTextEntry.isDirty = false;
+  }
   // onFocused: optional
   if (newViewProps.onFocused.isDirty) {
     swiftPart.setOnFocused(newViewProps.onFocused.value);

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
@@ -30,6 +30,7 @@ public protocol HybridNitroTextInputViewSpec_protocol: HybridObject, HybridView 
   var multiline: Bool? { get set }
   var placeholder: String? { get set }
   var placeholderTextColor: PlaceholderTextColor? { get set }
+  var secureTextEntry: Bool? { get set }
   var onFocused: (() -> Void)? { get set }
   var onBlurred: (() -> Void)? { get set }
   var onTextChanged: ((_ text: String) -> Void)? { get set }

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
@@ -466,6 +466,23 @@ open class HybridNitroTextInputViewSpec_cxx {
     }
   }
   
+  public final var secureTextEntry: bridge.std__optional_bool_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_bool_ in
+        if let __unwrappedValue = self.__implementation.secureTextEntry {
+          return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.secureTextEntry = newValue.value
+    }
+  }
+  
   public final var onFocused: bridge.std__optional_std__function_void____ {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
@@ -52,6 +52,8 @@ namespace margelo::nitro::nitrotextinput {
       prototype.registerHybridSetter("placeholder", &HybridNitroTextInputViewSpec::setPlaceholder);
       prototype.registerHybridGetter("placeholderTextColor", &HybridNitroTextInputViewSpec::getPlaceholderTextColor);
       prototype.registerHybridSetter("placeholderTextColor", &HybridNitroTextInputViewSpec::setPlaceholderTextColor);
+      prototype.registerHybridGetter("secureTextEntry", &HybridNitroTextInputViewSpec::getSecureTextEntry);
+      prototype.registerHybridSetter("secureTextEntry", &HybridNitroTextInputViewSpec::setSecureTextEntry);
       prototype.registerHybridGetter("onFocused", &HybridNitroTextInputViewSpec::getOnFocused);
       prototype.registerHybridSetter("onFocused", &HybridNitroTextInputViewSpec::setOnFocused);
       prototype.registerHybridGetter("onBlurred", &HybridNitroTextInputViewSpec::getOnBlurred);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -102,6 +102,8 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setPlaceholder(const std::optional<std::string>& placeholder) = 0;
       virtual std::optional<std::variant<std::string, double>> getPlaceholderTextColor() = 0;
       virtual void setPlaceholderTextColor(const std::optional<std::variant<std::string, double>>& placeholderTextColor) = 0;
+      virtual std::optional<bool> getSecureTextEntry() = 0;
+      virtual void setSecureTextEntry(std::optional<bool> secureTextEntry) = 0;
       virtual std::optional<std::function<void()>> getOnFocused() = 0;
       virtual void setOnFocused(const std::optional<std::function<void()>>& onFocused) = 0;
       virtual std::optional<std::function<void()>> getOnBlurred() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
@@ -215,6 +215,16 @@ namespace margelo::nitro::nitrotextinput::views {
         throw std::runtime_error(std::string("NitroTextInputView.placeholderTextColor: ") + exc.what());
       }
     }()),
+    secureTextEntry([&]() -> CachedProp<std::optional<bool>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("secureTextEntry", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.secureTextEntry;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<bool>>::fromRawValue(*runtime, value, sourceProps.secureTextEntry);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroTextInputView.secureTextEntry: ") + exc.what());
+      }
+    }()),
     onFocused([&]() -> CachedProp<std::optional<std::function<void()>>> {
       try {
         const react::RawValue* rawValue = rawProps.at("onFocused", nullptr, nullptr);
@@ -357,6 +367,7 @@ namespace margelo::nitro::nitrotextinput::views {
     multiline(other.multiline),
     placeholder(other.placeholder),
     placeholderTextColor(other.placeholderTextColor),
+    secureTextEntry(other.secureTextEntry),
     onFocused(other.onFocused),
     onBlurred(other.onBlurred),
     onTextChanged(other.onTextChanged),
@@ -391,6 +402,7 @@ namespace margelo::nitro::nitrotextinput::views {
       case hashString("multiline"): return true;
       case hashString("placeholder"): return true;
       case hashString("placeholderTextColor"): return true;
+      case hashString("secureTextEntry"): return true;
       case hashString("onFocused"): return true;
       case hashString("onBlurred"): return true;
       case hashString("onTextChanged"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -44,6 +44,7 @@
 #include <string>
 #include <variant>
 #include <optional>
+#include <optional>
 #include <functional>
 #include <optional>
 #include <functional>
@@ -115,6 +116,7 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<bool>> multiline;
     CachedProp<std::optional<std::string>> placeholder;
     CachedProp<std::optional<std::variant<std::string, double>>> placeholderTextColor;
+    CachedProp<std::optional<bool>> secureTextEntry;
     CachedProp<std::optional<std::function<void()>>> onFocused;
     CachedProp<std::optional<std::function<void()>>> onBlurred;
     CachedProp<std::optional<std::function<void(const std::string& /* text */)>>> onTextChanged;

--- a/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
@@ -23,6 +23,7 @@
     "multiline": true,
     "placeholder": true,
     "placeholderTextColor": true,
+    "secureTextEntry": true,
     "onFocused": true,
     "onBlurred": true,
     "onTextChanged": true,

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -123,6 +123,7 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   multiline?: boolean
   placeholder?: string
   placeholderTextColor?: PlaceholderTextColor
+  secureTextEntry?: boolean
   onFocused?: () => void
   onBlurred?: () => void
   onTextChanged?: (text: string) => void


### PR DESCRIPTION
Introduce secureTextEntry functionality for iOS single-line text inputs, allowing for secure text entry. Simplify the implementation and ensure caret position is maintained during toggling. Additionally, add a configuration file for subagents to enhance task management.