### PR TITLE
feat: add selectTextOnFocus property

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -50,12 +50,14 @@ export default function App() {
               })
             : '#0f0'
         }
+        selectTextOnFocus
         style={{ width: '100%' }}
       />
       <TextInput
         clearButtonMode="always"
         placeholder="React Native Text Input"
         enablesReturnKeyAutomatically
+        selectTextOnFocus
         style={{ width: '100%' }}
       />
       <StatusBar style="auto" />

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -981,7 +981,10 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
         self.textField.onDidBeginEditing = { [weak self] in
             guard let self = self else { return }
             if self.selectTextOnFocus == true {
-                self.textField.selectAll(nil)
+                // Defer selection to override iOS' tap-based caret placement
+                DispatchQueue.main.async { [weak self] in
+                    self?.textField.selectAll(nil)
+                }
             }
             self.onFocused?()
         }

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -371,6 +371,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             self.textField.clearTextOnFocus = self.clearTextOnFocus ?? false
         }
     }
+    var selectTextOnFocus: Bool? = false
     var contextMenuHidden: Bool? {
         didSet {
             Task {
@@ -959,7 +960,11 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
     // MARK: - Focus/Blur events
     private func wireTextFieldEventCallbacks() {
         self.textField.onDidBeginEditing = { [weak self] in
-            self?.onFocused?()
+            guard let self = self else { return }
+            if self.selectTextOnFocus == true {
+                self.textField.selectAll(nil)
+            }
+            self.onFocused?()
         }
         self.textField.onDidEndEditing = { [weak self] in
             guard let self = self else { return }

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -142,6 +142,15 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* clearTextOnFocus */)>("setClearTextOnFocus");
     method(_javaPart, clearTextOnFocus.has_value() ? jni::JBoolean::valueOf(clearTextOnFocus.value()) : nullptr);
   }
+  std::optional<bool> JHybridNitroTextInputViewSpec::getSelectTextOnFocus() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getSelectTextOnFocus");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(static_cast<bool>(__result->value())) : std::nullopt;
+  }
+  void JHybridNitroTextInputViewSpec::setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* selectTextOnFocus */)>("setSelectTextOnFocus");
+    method(_javaPart, selectTextOnFocus.has_value() ? jni::JBoolean::valueOf(selectTextOnFocus.value()) : nullptr);
+  }
   std::optional<bool> JHybridNitroTextInputViewSpec::getContextMenuHidden() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getContextMenuHidden");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
@@ -65,6 +65,8 @@ namespace margelo::nitro::nitrotextinput {
     void setClearButtonMode(std::optional<ClearButtonMode> clearButtonMode) override;
     std::optional<bool> getClearTextOnFocus() override;
     void setClearTextOnFocus(std::optional<bool> clearTextOnFocus) override;
+    std::optional<bool> getSelectTextOnFocus() override;
+    void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) override;
     std::optional<bool> getContextMenuHidden() override;
     void setContextMenuHidden(std::optional<bool> contextMenuHidden) override;
     std::optional<std::string> getDefaultValue() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
@@ -68,6 +68,10 @@ void JHybridNitroTextInputViewStateUpdater::updateViewProps(jni::alias_ref<jni::
     view->setClearTextOnFocus(props.clearTextOnFocus.value);
     // TODO: Set isDirty = false
   }
+  if (props.selectTextOnFocus.isDirty) {
+    view->setSelectTextOnFocus(props.selectTextOnFocus.value);
+    // TODO: Set isDirty = false
+  }
   if (props.contextMenuHidden.isDirty) {
     view->setContextMenuHidden(props.contextMenuHidden.value);
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
@@ -90,6 +90,12 @@ abstract class HybridNitroTextInputViewSpec: HybridView() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var selectTextOnFocus: Boolean?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var contextMenuHidden: Boolean?
   
   @get:DoNotStrip

--- a/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
@@ -132,6 +132,13 @@ namespace margelo::nitro::nitrotextinput {
     inline void setClearTextOnFocus(std::optional<bool> clearTextOnFocus) noexcept override {
       _swiftPart.setClearTextOnFocus(clearTextOnFocus);
     }
+    inline std::optional<bool> getSelectTextOnFocus() noexcept override {
+      auto __result = _swiftPart.getSelectTextOnFocus();
+      return __result;
+    }
+    inline void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) noexcept override {
+      _swiftPart.setSelectTextOnFocus(selectTextOnFocus);
+    }
     inline std::optional<bool> getContextMenuHidden() noexcept override {
       auto __result = _swiftPart.getContextMenuHidden();
       return __result;

--- a/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
@@ -111,6 +111,11 @@ using namespace margelo::nitro::nitrotextinput::views;
     swiftPart.setClearTextOnFocus(newViewProps.clearTextOnFocus.value);
     newViewProps.clearTextOnFocus.isDirty = false;
   }
+  // selectTextOnFocus: optional
+  if (newViewProps.selectTextOnFocus.isDirty) {
+    swiftPart.setSelectTextOnFocus(newViewProps.selectTextOnFocus.value);
+    newViewProps.selectTextOnFocus.isDirty = false;
+  }
   // contextMenuHidden: optional
   if (newViewProps.contextMenuHidden.isDirty) {
     swiftPart.setContextMenuHidden(newViewProps.contextMenuHidden.value);

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
@@ -19,6 +19,7 @@ public protocol HybridNitroTextInputViewSpec_protocol: HybridObject, HybridView 
   var caretHidden: Bool? { get set }
   var clearButtonMode: ClearButtonMode? { get set }
   var clearTextOnFocus: Bool? { get set }
+  var selectTextOnFocus: Bool? { get set }
   var contextMenuHidden: Bool? { get set }
   var defaultValue: String? { get set }
   var editable: Bool? { get set }

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
@@ -242,6 +242,23 @@ open class HybridNitroTextInputViewSpec_cxx {
     }
   }
   
+  public final var selectTextOnFocus: bridge.std__optional_bool_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_bool_ in
+        if let __unwrappedValue = self.__implementation.selectTextOnFocus {
+          return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.selectTextOnFocus = newValue.value
+    }
+  }
+  
   public final var contextMenuHidden: bridge.std__optional_bool_ {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
@@ -30,6 +30,8 @@ namespace margelo::nitro::nitrotextinput {
       prototype.registerHybridSetter("clearButtonMode", &HybridNitroTextInputViewSpec::setClearButtonMode);
       prototype.registerHybridGetter("clearTextOnFocus", &HybridNitroTextInputViewSpec::getClearTextOnFocus);
       prototype.registerHybridSetter("clearTextOnFocus", &HybridNitroTextInputViewSpec::setClearTextOnFocus);
+      prototype.registerHybridGetter("selectTextOnFocus", &HybridNitroTextInputViewSpec::getSelectTextOnFocus);
+      prototype.registerHybridSetter("selectTextOnFocus", &HybridNitroTextInputViewSpec::setSelectTextOnFocus);
       prototype.registerHybridGetter("contextMenuHidden", &HybridNitroTextInputViewSpec::getContextMenuHidden);
       prototype.registerHybridSetter("contextMenuHidden", &HybridNitroTextInputViewSpec::setContextMenuHidden);
       prototype.registerHybridGetter("defaultValue", &HybridNitroTextInputViewSpec::getDefaultValue);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -83,6 +83,8 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setClearButtonMode(std::optional<ClearButtonMode> clearButtonMode) = 0;
       virtual std::optional<bool> getClearTextOnFocus() = 0;
       virtual void setClearTextOnFocus(std::optional<bool> clearTextOnFocus) = 0;
+      virtual std::optional<bool> getSelectTextOnFocus() = 0;
+      virtual void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) = 0;
       virtual std::optional<bool> getContextMenuHidden() = 0;
       virtual void setContextMenuHidden(std::optional<bool> contextMenuHidden) = 0;
       virtual std::optional<std::string> getDefaultValue() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
@@ -105,6 +105,16 @@ namespace margelo::nitro::nitrotextinput::views {
         throw std::runtime_error(std::string("NitroTextInputView.clearTextOnFocus: ") + exc.what());
       }
     }()),
+    selectTextOnFocus([&]() -> CachedProp<std::optional<bool>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("selectTextOnFocus", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.selectTextOnFocus;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<bool>>::fromRawValue(*runtime, value, sourceProps.selectTextOnFocus);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroTextInputView.selectTextOnFocus: ") + exc.what());
+      }
+    }()),
     contextMenuHidden([&]() -> CachedProp<std::optional<bool>> {
       try {
         const react::RawValue* rawValue = rawProps.at("contextMenuHidden", nullptr, nullptr);
@@ -376,6 +386,7 @@ namespace margelo::nitro::nitrotextinput::views {
     caretHidden(other.caretHidden),
     clearButtonMode(other.clearButtonMode),
     clearTextOnFocus(other.clearTextOnFocus),
+    selectTextOnFocus(other.selectTextOnFocus),
     contextMenuHidden(other.contextMenuHidden),
     defaultValue(other.defaultValue),
     editable(other.editable),
@@ -413,6 +424,7 @@ namespace margelo::nitro::nitrotextinput::views {
       case hashString("caretHidden"): return true;
       case hashString("clearButtonMode"): return true;
       case hashString("clearTextOnFocus"): return true;
+      case hashString("selectTextOnFocus"): return true;
       case hashString("contextMenuHidden"): return true;
       case hashString("defaultValue"): return true;
       case hashString("editable"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -28,6 +28,7 @@
 #include <optional>
 #include <optional>
 #include <optional>
+#include <optional>
 #include <string>
 #include <optional>
 #include <optional>
@@ -110,6 +111,7 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<bool>> caretHidden;
     CachedProp<std::optional<ClearButtonMode>> clearButtonMode;
     CachedProp<std::optional<bool>> clearTextOnFocus;
+    CachedProp<std::optional<bool>> selectTextOnFocus;
     CachedProp<std::optional<bool>> contextMenuHidden;
     CachedProp<std::optional<std::string>> defaultValue;
     CachedProp<std::optional<bool>> editable;

--- a/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
@@ -12,6 +12,7 @@
     "caretHidden": true,
     "clearButtonMode": true,
     "clearTextOnFocus": true,
+    "selectTextOnFocus": true,
     "contextMenuHidden": true,
     "defaultValue": true,
     "editable": true,

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -109,6 +109,7 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   caretHidden?: boolean
   clearButtonMode?: ClearButtonMode
   clearTextOnFocus?: boolean
+  selectTextOnFocus?: boolean
   contextMenuHidden?: boolean
   /**
    * Provides an initial value that will change when the user starts typing. Useful for simple use-cases where you don’t want to deal with listening to events and updating the value prop to keep the controlled state in sync.


### PR DESCRIPTION
Introduce a new property, selectTextOnFocus, to allow text selection on focus for single-line inputs on iOS. Reorganize related properties for better readability and update examples to demonstrate the new feature.