### PR TITLE
feat: add showSoftInputOnFocus property for iOS text input

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -51,6 +51,7 @@ export default function App() {
             : '#0f0'
         }
         selectTextOnFocus
+        showSoftInputOnFocus={false}
         style={{ width: '100%' }}
       />
       <TextInput

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
         allowFontScaling
         autoCapitalize="words"
         autoCorrect
-        autoFocus={true}
+        autoFocus={false}
         caretHidden={false}
         clearButtonMode="while-editing"
         clearTextOnFocus={false}
@@ -51,10 +51,11 @@ export default function App() {
             : '#0f0'
         }
         selectTextOnFocus
-        showSoftInputOnFocus={false}
+        showSoftInputOnFocus={true}
         style={{ width: '100%' }}
       />
       <TextInput
+        autoFocus={false}
         clearButtonMode="always"
         placeholder="React Native Text Input"
         enablesReturnKeyAutomatically

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -343,6 +343,13 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
         didSet {
             Task { @MainActor in
                 if self.autoFocus == true {
+                    // Ensure inputView reflects showSoftInputOnFocus before focusing
+                    let show = self.showSoftInputOnFocus ?? true
+                    if show {
+                        self.textField.inputView = nil
+                    } else {
+                        self.textField.inputView = UIView()
+                    }
                     self.textField.becomeFirstResponder()
                 } else {
                     self.textField.resignFirstResponder()

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -387,21 +387,6 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
-    var showSoftInputOnFocus: Bool? = true {
-        didSet {
-            Task { @MainActor in
-                let show = self.showSoftInputOnFocus ?? true
-                if show {
-                    self.textField.inputView = nil
-                    if self.textField.isFirstResponder {
-                        self.textField.reloadInputViews()
-                    }
-                } else {
-                    self.textField.inputView = UIView()
-                }
-            }
-        }
-    }
     var defaultValue: String? {
         didSet {
             Task { @MainActor in
@@ -427,14 +412,6 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
                 @MainActor in
                 self.textField.enablesReturnKeyAutomatically =
                     self.enablesReturnKeyAutomatically ?? false
-            }
-        }
-    }
-    var returnKeyType: ReturnKeyType? {
-        didSet {
-            Task {
-                @MainActor in
-                self.updateReturnKeyType()
             }
         }
     }
@@ -479,6 +456,14 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
+    var returnKeyType: ReturnKeyType? {
+        didSet {
+            Task {
+                @MainActor in
+                self.updateReturnKeyType()
+            }
+        }
+    }
     var secureTextEntry: Bool? {
         didSet {
             Task { @MainActor in
@@ -516,6 +501,21 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
         }
     }
     var selectTextOnFocus: Bool? = false
+    var showSoftInputOnFocus: Bool? = true {
+        didSet {
+            Task { @MainActor in
+                let show = self.showSoftInputOnFocus ?? true
+                if show {
+                    self.textField.inputView = nil
+                    if self.textField.isFirstResponder {
+                        self.textField.reloadInputViews()
+                    }
+                } else {
+                    self.textField.inputView = UIView()
+                }
+            }
+        }
+    }
 
     var onInitialHeightMeasured: ((_ height: Double) -> Void)?
     var onFocused: (() -> Void)?

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -387,6 +387,21 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
+    var showSoftInputOnFocus: Bool? = true {
+        didSet {
+            Task { @MainActor in
+                let show = self.showSoftInputOnFocus ?? true
+                if show {
+                    self.textField.inputView = nil
+                    if self.textField.isFirstResponder {
+                        self.textField.reloadInputViews()
+                    }
+                } else {
+                    self.textField.inputView = UIView()
+                }
+            }
+        }
+    }
     var defaultValue: String? {
         didSet {
             Task { @MainActor in

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -160,6 +160,15 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* contextMenuHidden */)>("setContextMenuHidden");
     method(_javaPart, contextMenuHidden.has_value() ? jni::JBoolean::valueOf(contextMenuHidden.value()) : nullptr);
   }
+  std::optional<bool> JHybridNitroTextInputViewSpec::getShowSoftInputOnFocus() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getShowSoftInputOnFocus");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(static_cast<bool>(__result->value())) : std::nullopt;
+  }
+  void JHybridNitroTextInputViewSpec::setShowSoftInputOnFocus(std::optional<bool> showSoftInputOnFocus) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* showSoftInputOnFocus */)>("setShowSoftInputOnFocus");
+    method(_javaPart, showSoftInputOnFocus.has_value() ? jni::JBoolean::valueOf(showSoftInputOnFocus.value()) : nullptr);
+  }
   std::optional<std::string> JHybridNitroTextInputViewSpec::getDefaultValue() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getDefaultValue");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
@@ -69,6 +69,8 @@ namespace margelo::nitro::nitrotextinput {
     void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) override;
     std::optional<bool> getContextMenuHidden() override;
     void setContextMenuHidden(std::optional<bool> contextMenuHidden) override;
+    std::optional<bool> getShowSoftInputOnFocus() override;
+    void setShowSoftInputOnFocus(std::optional<bool> showSoftInputOnFocus) override;
     std::optional<std::string> getDefaultValue() override;
     void setDefaultValue(const std::optional<std::string>& defaultValue) override;
     std::optional<bool> getEditable() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
@@ -76,6 +76,10 @@ void JHybridNitroTextInputViewStateUpdater::updateViewProps(jni::alias_ref<jni::
     view->setContextMenuHidden(props.contextMenuHidden.value);
     // TODO: Set isDirty = false
   }
+  if (props.showSoftInputOnFocus.isDirty) {
+    view->setShowSoftInputOnFocus(props.showSoftInputOnFocus.value);
+    // TODO: Set isDirty = false
+  }
   if (props.defaultValue.isDirty) {
     view->setDefaultValue(props.defaultValue.value);
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
@@ -102,6 +102,12 @@ abstract class HybridNitroTextInputViewSpec: HybridView() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var showSoftInputOnFocus: Boolean?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var defaultValue: String?
   
   @get:DoNotStrip

--- a/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
@@ -146,6 +146,13 @@ namespace margelo::nitro::nitrotextinput {
     inline void setContextMenuHidden(std::optional<bool> contextMenuHidden) noexcept override {
       _swiftPart.setContextMenuHidden(contextMenuHidden);
     }
+    inline std::optional<bool> getShowSoftInputOnFocus() noexcept override {
+      auto __result = _swiftPart.getShowSoftInputOnFocus();
+      return __result;
+    }
+    inline void setShowSoftInputOnFocus(std::optional<bool> showSoftInputOnFocus) noexcept override {
+      _swiftPart.setShowSoftInputOnFocus(showSoftInputOnFocus);
+    }
     inline std::optional<std::string> getDefaultValue() noexcept override {
       auto __result = _swiftPart.getDefaultValue();
       return __result;

--- a/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
@@ -121,6 +121,11 @@ using namespace margelo::nitro::nitrotextinput::views;
     swiftPart.setContextMenuHidden(newViewProps.contextMenuHidden.value);
     newViewProps.contextMenuHidden.isDirty = false;
   }
+  // showSoftInputOnFocus: optional
+  if (newViewProps.showSoftInputOnFocus.isDirty) {
+    swiftPart.setShowSoftInputOnFocus(newViewProps.showSoftInputOnFocus.value);
+    newViewProps.showSoftInputOnFocus.isDirty = false;
+  }
   // defaultValue: optional
   if (newViewProps.defaultValue.isDirty) {
     swiftPart.setDefaultValue(newViewProps.defaultValue.value);

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
@@ -21,6 +21,7 @@ public protocol HybridNitroTextInputViewSpec_protocol: HybridObject, HybridView 
   var clearTextOnFocus: Bool? { get set }
   var selectTextOnFocus: Bool? { get set }
   var contextMenuHidden: Bool? { get set }
+  var showSoftInputOnFocus: Bool? { get set }
   var defaultValue: String? { get set }
   var editable: Bool? { get set }
   var enablesReturnKeyAutomatically: Bool? { get set }

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
@@ -276,6 +276,23 @@ open class HybridNitroTextInputViewSpec_cxx {
     }
   }
   
+  public final var showSoftInputOnFocus: bridge.std__optional_bool_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_bool_ in
+        if let __unwrappedValue = self.__implementation.showSoftInputOnFocus {
+          return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.showSoftInputOnFocus = newValue.value
+    }
+  }
+  
   public final var defaultValue: bridge.std__optional_std__string_ {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
@@ -34,6 +34,8 @@ namespace margelo::nitro::nitrotextinput {
       prototype.registerHybridSetter("selectTextOnFocus", &HybridNitroTextInputViewSpec::setSelectTextOnFocus);
       prototype.registerHybridGetter("contextMenuHidden", &HybridNitroTextInputViewSpec::getContextMenuHidden);
       prototype.registerHybridSetter("contextMenuHidden", &HybridNitroTextInputViewSpec::setContextMenuHidden);
+      prototype.registerHybridGetter("showSoftInputOnFocus", &HybridNitroTextInputViewSpec::getShowSoftInputOnFocus);
+      prototype.registerHybridSetter("showSoftInputOnFocus", &HybridNitroTextInputViewSpec::setShowSoftInputOnFocus);
       prototype.registerHybridGetter("defaultValue", &HybridNitroTextInputViewSpec::getDefaultValue);
       prototype.registerHybridSetter("defaultValue", &HybridNitroTextInputViewSpec::setDefaultValue);
       prototype.registerHybridGetter("editable", &HybridNitroTextInputViewSpec::getEditable);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -87,6 +87,8 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) = 0;
       virtual std::optional<bool> getContextMenuHidden() = 0;
       virtual void setContextMenuHidden(std::optional<bool> contextMenuHidden) = 0;
+      virtual std::optional<bool> getShowSoftInputOnFocus() = 0;
+      virtual void setShowSoftInputOnFocus(std::optional<bool> showSoftInputOnFocus) = 0;
       virtual std::optional<std::string> getDefaultValue() = 0;
       virtual void setDefaultValue(const std::optional<std::string>& defaultValue) = 0;
       virtual std::optional<bool> getEditable() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
@@ -125,6 +125,16 @@ namespace margelo::nitro::nitrotextinput::views {
         throw std::runtime_error(std::string("NitroTextInputView.contextMenuHidden: ") + exc.what());
       }
     }()),
+    showSoftInputOnFocus([&]() -> CachedProp<std::optional<bool>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("showSoftInputOnFocus", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.showSoftInputOnFocus;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<bool>>::fromRawValue(*runtime, value, sourceProps.showSoftInputOnFocus);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroTextInputView.showSoftInputOnFocus: ") + exc.what());
+      }
+    }()),
     defaultValue([&]() -> CachedProp<std::optional<std::string>> {
       try {
         const react::RawValue* rawValue = rawProps.at("defaultValue", nullptr, nullptr);
@@ -388,6 +398,7 @@ namespace margelo::nitro::nitrotextinput::views {
     clearTextOnFocus(other.clearTextOnFocus),
     selectTextOnFocus(other.selectTextOnFocus),
     contextMenuHidden(other.contextMenuHidden),
+    showSoftInputOnFocus(other.showSoftInputOnFocus),
     defaultValue(other.defaultValue),
     editable(other.editable),
     enablesReturnKeyAutomatically(other.enablesReturnKeyAutomatically),
@@ -426,6 +437,7 @@ namespace margelo::nitro::nitrotextinput::views {
       case hashString("clearTextOnFocus"): return true;
       case hashString("selectTextOnFocus"): return true;
       case hashString("contextMenuHidden"): return true;
+      case hashString("showSoftInputOnFocus"): return true;
       case hashString("defaultValue"): return true;
       case hashString("editable"): return true;
       case hashString("enablesReturnKeyAutomatically"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -29,6 +29,7 @@
 #include <optional>
 #include <optional>
 #include <optional>
+#include <optional>
 #include <string>
 #include <optional>
 #include <optional>
@@ -113,6 +114,7 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<bool>> clearTextOnFocus;
     CachedProp<std::optional<bool>> selectTextOnFocus;
     CachedProp<std::optional<bool>> contextMenuHidden;
+    CachedProp<std::optional<bool>> showSoftInputOnFocus;
     CachedProp<std::optional<std::string>> defaultValue;
     CachedProp<std::optional<bool>> editable;
     CachedProp<std::optional<bool>> enablesReturnKeyAutomatically;

--- a/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
@@ -14,6 +14,7 @@
     "clearTextOnFocus": true,
     "selectTextOnFocus": true,
     "contextMenuHidden": true,
+    "showSoftInputOnFocus": true,
     "defaultValue": true,
     "editable": true,
     "enablesReturnKeyAutomatically": true,

--- a/src/nitro-text-input.tsx
+++ b/src/nitro-text-input.tsx
@@ -85,6 +85,7 @@ export function NitroTextInput(props: NitroTextInputProps) {
     enterKeyHint,
     returnKeyType,
     selectionColor,
+    showSoftInputOnFocus = true,
     ...others
   } = props
 
@@ -119,8 +120,8 @@ export function NitroTextInput(props: NitroTextInputProps) {
   }
 
   // Handle showSoftInputOnFocus for inputMode 'none'
-  // const shouldShowSoftInput =
-  //   props.inputMode === 'none' ? false : props.showSoftInputOnFocus
+  const shouldShowSoftInput =
+    props.inputMode === 'none' ? false : showSoftInputOnFocus
 
   const composedStyle = () => {
     if (!hasExplicitHeight && measuredInitialHeight != null) {
@@ -182,6 +183,8 @@ export function NitroTextInput(props: NitroTextInputProps) {
       placeholderTextColor={toProcessedColor(placeholderTextColor)}
       returnKeyType={resolvedReturnKeyType}
       selectionColor={toProcessedColor(selectionColor)}
+      showSoftInputOnFocus={shouldShowSoftInput}
+      // Event handlers
       onBlurred={{ f: onBlur }}
       onTextChanged={{ f: onChangeText }}
       onEditingEnded={{ f: onEndEditing }}

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -109,8 +109,9 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   caretHidden?: boolean
   clearButtonMode?: ClearButtonMode
   clearTextOnFocus?: boolean
-  selectTextOnFocus?: boolean
   contextMenuHidden?: boolean
+  selectTextOnFocus?: boolean
+  showSoftInputOnFocus?: boolean
   /**
    * Provides an initial value that will change when the user starts typing. Useful for simple use-cases where you don’t want to deal with listening to events and updating the value prop to keep the controlled state in sync.
    *

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -110,15 +110,6 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   clearButtonMode?: ClearButtonMode
   clearTextOnFocus?: boolean
   contextMenuHidden?: boolean
-  selectTextOnFocus?: boolean
-  showSoftInputOnFocus?: boolean
-  /**
-   * Provides an initial value that will change when the user starts typing. Useful for simple use-cases where you don’t want to deal with listening to events and updating the value prop to keep the controlled state in sync.
-   *
-   * 注意: NitroTextInput の `defaultValue` は「初期化時にのみ」反映されます。マウント後にこの props を更新しても、既に表示中のテキストは上書きされません。
-   * - 初回マウント時、フィールドが空の場合に初期値として適用されます。
-   * - ユーザー入力などでテキストが既に存在する場合は上書きしません。
-   */
   defaultValue?: string
   editable?: boolean
   enablesReturnKeyAutomatically?: boolean
@@ -129,9 +120,12 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   multiline?: boolean
   placeholder?: string
   placeholderTextColor?: ProcessedColor
+  returnKeyType?: ReturnKeyType
+  selection?: TextSelection
   selectionColor?: ProcessedColor
   secureTextEntry?: boolean
-  selection?: TextSelection
+  selectTextOnFocus?: boolean
+  showSoftInputOnFocus?: boolean
   onFocused?: () => void
   onBlurred?: () => void
   onTextChanged?: (text: string) => void
@@ -153,7 +147,6 @@ export interface NitroTextInputViewProps extends HybridViewProps {
     locationY: number,
     timestamp: number
   ) => void
-  returnKeyType?: ReturnKeyType
   /**
    * Called once when the initial height has been measured (pt).
    */


### PR DESCRIPTION
Introduce the showSoftInputOnFocus property to control the visibility of the soft input based on focus state in iOS. Reorganize related properties for better clarity and ensure proper functionality during autoFocus. Update examples to reflect these changes.