### PR TITLE
feat: add spellCheck support for iOS text input

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -52,6 +52,7 @@ export default function App() {
         }
         selectTextOnFocus
         showSoftInputOnFocus={true}
+        spellCheck={true}
         style={{ width: '100%' }}
       />
       <TextInput
@@ -60,6 +61,7 @@ export default function App() {
         maxLength={12}
         placeholder="React Native Text Input"
         enablesReturnKeyAutomatically
+        spellCheck={false}
         style={{ width: '100%' }}
       />
       <StatusBar style="auto" />

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -339,6 +339,17 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
+    var spellCheck: Bool? {
+        didSet {
+            Task { @MainActor in
+                if let v = self.spellCheck {
+                    self.textField.spellCheckingType = v ? .yes : .no
+                } else {
+                    self.textField.spellCheckingType = .default
+                }
+            }
+        }
+    }
     var autoFocus: Bool? {
         didSet {
             Task { @MainActor in

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -339,17 +339,6 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
-    var spellCheck: Bool? {
-        didSet {
-            Task { @MainActor in
-                if let v = self.spellCheck {
-                    self.textField.spellCheckingType = v ? .yes : .no
-                } else {
-                    self.textField.spellCheckingType = .default
-                }
-            }
-        }
-    }
     var autoFocus: Bool? {
         didSet {
             Task { @MainActor in
@@ -489,21 +478,6 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
-    var smartInsertDelete: Bool? {
-        didSet {
-            Task { @MainActor in
-                if #available(iOS 13.0, *) {
-                    if let enabled = self.smartInsertDelete {
-                        self.textField.smartInsertDeleteType =
-                            enabled
-                            ? .yes : .no
-                    } else {
-                        self.textField.smartInsertDeleteType = .default
-                    }
-                }
-            }
-        }
-    }
     var selection: TextSelection? {
         didSet {
             Task { @MainActor in
@@ -545,6 +519,32 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
                     }
                 } else {
                     self.textField.inputView = UIView()
+                }
+            }
+        }
+    }
+    var smartInsertDelete: Bool? {
+        didSet {
+            Task { @MainActor in
+                if #available(iOS 13.0, *) {
+                    if let enabled = self.smartInsertDelete {
+                        self.textField.smartInsertDeleteType =
+                            enabled
+                            ? .yes : .no
+                    } else {
+                        self.textField.smartInsertDeleteType = .default
+                    }
+                }
+            }
+        }
+    }
+    var spellCheck: Bool? {
+        didSet {
+            Task { @MainActor in
+                if let v = self.spellCheck {
+                    self.textField.spellCheckingType = v ? .yes : .no
+                } else {
+                    self.textField.spellCheckingType = .default
                 }
             }
         }

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -277,6 +277,15 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* secureTextEntry */)>("setSecureTextEntry");
     method(_javaPart, secureTextEntry.has_value() ? jni::JBoolean::valueOf(secureTextEntry.value()) : nullptr);
   }
+  std::optional<bool> JHybridNitroTextInputViewSpec::getSpellCheck() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getSpellCheck");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(static_cast<bool>(__result->value())) : std::nullopt;
+  }
+  void JHybridNitroTextInputViewSpec::setSpellCheck(std::optional<bool> spellCheck) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* spellCheck */)>("setSpellCheck");
+    method(_javaPart, spellCheck.has_value() ? jni::JBoolean::valueOf(spellCheck.value()) : nullptr);
+  }
   std::optional<bool> JHybridNitroTextInputViewSpec::getSelectTextOnFocus() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getSelectTextOnFocus");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
@@ -95,6 +95,8 @@ namespace margelo::nitro::nitrotextinput {
     void setSelectionColor(const std::optional<std::variant<std::string, double>>& selectionColor) override;
     std::optional<bool> getSecureTextEntry() override;
     void setSecureTextEntry(std::optional<bool> secureTextEntry) override;
+    std::optional<bool> getSpellCheck() override;
+    void setSpellCheck(std::optional<bool> spellCheck) override;
     std::optional<bool> getSelectTextOnFocus() override;
     void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) override;
     std::optional<bool> getShowSoftInputOnFocus() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
@@ -128,6 +128,10 @@ void JHybridNitroTextInputViewStateUpdater::updateViewProps(jni::alias_ref<jni::
     view->setSecureTextEntry(props.secureTextEntry.value);
     // TODO: Set isDirty = false
   }
+  if (props.spellCheck.isDirty) {
+    view->setSpellCheck(props.spellCheck.value);
+    // TODO: Set isDirty = false
+  }
   if (props.selectTextOnFocus.isDirty) {
     view->setSelectTextOnFocus(props.selectTextOnFocus.value);
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
@@ -180,6 +180,12 @@ abstract class HybridNitroTextInputViewSpec: HybridView() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var spellCheck: Boolean?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var selectTextOnFocus: Boolean?
   
   @get:DoNotStrip

--- a/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
@@ -237,6 +237,13 @@ namespace margelo::nitro::nitrotextinput {
     inline void setSecureTextEntry(std::optional<bool> secureTextEntry) noexcept override {
       _swiftPart.setSecureTextEntry(secureTextEntry);
     }
+    inline std::optional<bool> getSpellCheck() noexcept override {
+      auto __result = _swiftPart.getSpellCheck();
+      return __result;
+    }
+    inline void setSpellCheck(std::optional<bool> spellCheck) noexcept override {
+      _swiftPart.setSpellCheck(spellCheck);
+    }
     inline std::optional<bool> getSelectTextOnFocus() noexcept override {
       auto __result = _swiftPart.getSelectTextOnFocus();
       return __result;

--- a/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
@@ -186,6 +186,11 @@ using namespace margelo::nitro::nitrotextinput::views;
     swiftPart.setSecureTextEntry(newViewProps.secureTextEntry.value);
     newViewProps.secureTextEntry.isDirty = false;
   }
+  // spellCheck: optional
+  if (newViewProps.spellCheck.isDirty) {
+    swiftPart.setSpellCheck(newViewProps.spellCheck.value);
+    newViewProps.spellCheck.isDirty = false;
+  }
   // selectTextOnFocus: optional
   if (newViewProps.selectTextOnFocus.isDirty) {
     swiftPart.setSelectTextOnFocus(newViewProps.selectTextOnFocus.value);

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
@@ -34,6 +34,7 @@ public protocol HybridNitroTextInputViewSpec_protocol: HybridObject, HybridView 
   var selection: TextSelection? { get set }
   var selectionColor: ProcessedColor? { get set }
   var secureTextEntry: Bool? { get set }
+  var spellCheck: Bool? { get set }
   var selectTextOnFocus: Bool? { get set }
   var showSoftInputOnFocus: Bool? { get set }
   var smartInsertDelete: Bool? { get set }

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
@@ -565,6 +565,23 @@ open class HybridNitroTextInputViewSpec_cxx {
     }
   }
   
+  public final var spellCheck: bridge.std__optional_bool_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_bool_ in
+        if let __unwrappedValue = self.__implementation.spellCheck {
+          return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.spellCheck = newValue.value
+    }
+  }
+  
   public final var selectTextOnFocus: bridge.std__optional_bool_ {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
@@ -60,6 +60,8 @@ namespace margelo::nitro::nitrotextinput {
       prototype.registerHybridSetter("selectionColor", &HybridNitroTextInputViewSpec::setSelectionColor);
       prototype.registerHybridGetter("secureTextEntry", &HybridNitroTextInputViewSpec::getSecureTextEntry);
       prototype.registerHybridSetter("secureTextEntry", &HybridNitroTextInputViewSpec::setSecureTextEntry);
+      prototype.registerHybridGetter("spellCheck", &HybridNitroTextInputViewSpec::getSpellCheck);
+      prototype.registerHybridSetter("spellCheck", &HybridNitroTextInputViewSpec::setSpellCheck);
       prototype.registerHybridGetter("selectTextOnFocus", &HybridNitroTextInputViewSpec::getSelectTextOnFocus);
       prototype.registerHybridSetter("selectTextOnFocus", &HybridNitroTextInputViewSpec::setSelectTextOnFocus);
       prototype.registerHybridGetter("showSoftInputOnFocus", &HybridNitroTextInputViewSpec::getShowSoftInputOnFocus);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -113,6 +113,8 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setSelectionColor(const std::optional<std::variant<std::string, double>>& selectionColor) = 0;
       virtual std::optional<bool> getSecureTextEntry() = 0;
       virtual void setSecureTextEntry(std::optional<bool> secureTextEntry) = 0;
+      virtual std::optional<bool> getSpellCheck() = 0;
+      virtual void setSpellCheck(std::optional<bool> spellCheck) = 0;
       virtual std::optional<bool> getSelectTextOnFocus() = 0;
       virtual void setSelectTextOnFocus(std::optional<bool> selectTextOnFocus) = 0;
       virtual std::optional<bool> getShowSoftInputOnFocus() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
@@ -255,6 +255,16 @@ namespace margelo::nitro::nitrotextinput::views {
         throw std::runtime_error(std::string("NitroTextInputView.secureTextEntry: ") + exc.what());
       }
     }()),
+    spellCheck([&]() -> CachedProp<std::optional<bool>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("spellCheck", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.spellCheck;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<bool>>::fromRawValue(*runtime, value, sourceProps.spellCheck);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroTextInputView.spellCheck: ") + exc.what());
+      }
+    }()),
     selectTextOnFocus([&]() -> CachedProp<std::optional<bool>> {
       try {
         const react::RawValue* rawValue = rawProps.at("selectTextOnFocus", nullptr, nullptr);
@@ -421,6 +431,7 @@ namespace margelo::nitro::nitrotextinput::views {
     selection(other.selection),
     selectionColor(other.selectionColor),
     secureTextEntry(other.secureTextEntry),
+    spellCheck(other.spellCheck),
     selectTextOnFocus(other.selectTextOnFocus),
     showSoftInputOnFocus(other.showSoftInputOnFocus),
     smartInsertDelete(other.smartInsertDelete),
@@ -461,6 +472,7 @@ namespace margelo::nitro::nitrotextinput::views {
       case hashString("selection"): return true;
       case hashString("selectionColor"): return true;
       case hashString("secureTextEntry"): return true;
+      case hashString("spellCheck"): return true;
       case hashString("selectTextOnFocus"): return true;
       case hashString("showSoftInputOnFocus"): return true;
       case hashString("smartInsertDelete"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -55,6 +55,7 @@
 #include <optional>
 #include <optional>
 #include <optional>
+#include <optional>
 #include <functional>
 #include <optional>
 #include <functional>
@@ -128,6 +129,7 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<TextSelection>> selection;
     CachedProp<std::optional<std::variant<std::string, double>>> selectionColor;
     CachedProp<std::optional<bool>> secureTextEntry;
+    CachedProp<std::optional<bool>> spellCheck;
     CachedProp<std::optional<bool>> selectTextOnFocus;
     CachedProp<std::optional<bool>> showSoftInputOnFocus;
     CachedProp<std::optional<bool>> smartInsertDelete;

--- a/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
@@ -27,6 +27,7 @@
     "selection": true,
     "selectionColor": true,
     "secureTextEntry": true,
+    "spellCheck": true,
     "selectTextOnFocus": true,
     "showSoftInputOnFocus": true,
     "smartInsertDelete": true,

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -124,6 +124,7 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   selection?: TextSelection
   selectionColor?: ProcessedColor
   secureTextEntry?: boolean
+  spellCheck?: boolean
   selectTextOnFocus?: boolean
   showSoftInputOnFocus?: boolean
   smartInsertDelete?: boolean


### PR DESCRIPTION
Introduce spellCheck property for iOS text input, enhancing text input functionality. Refactor code for better structure and update examples to demonstrate the new feature.