### PR TITLE
feat: add password rules support for text input

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -42,7 +42,6 @@ export default function App() {
               })
             : '#00f'
         }
-        secureTextEntry={false}
         selectionColor={
           Platform.OS === 'ios'
             ? DynamicColorIOS({
@@ -51,6 +50,7 @@ export default function App() {
               })
             : '#0f0'
         }
+        secureTextEntry={false}
         selectTextOnFocus={false}
         showSoftInputOnFocus={true}
         spellCheck={true}

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -447,6 +447,21 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
             }
         }
     }
+    var passwordRules: String? {
+        didSet {
+            Task { @MainActor in
+                if #available(iOS 12.0, *) {
+                    if let rules = self.passwordRules, rules.isEmpty == false {
+                        self.textField.passwordRules = UITextInputPasswordRules(
+                            passwordRulesDescriptor: rules
+                        )
+                    } else {
+                        self.textField.passwordRules = nil
+                    }
+                }
+            }
+        }
+    }
     var keyboardAppearance: KeyboardAppearance? {
         didSet {
             Task { @MainActor in

--- a/ios/HybridTextInputView.swift
+++ b/ios/HybridTextInputView.swift
@@ -453,7 +453,7 @@ class HybridTextInputView: HybridNitroTextInputViewSpec {
                 if #available(iOS 12.0, *) {
                     if let rules = self.passwordRules, rules.isEmpty == false {
                         self.textField.passwordRules = UITextInputPasswordRules(
-                            passwordRulesDescriptor: rules
+                            descriptor: rules
                         )
                     } else {
                         self.textField.passwordRules = nil

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -231,6 +231,15 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* multiline */)>("setMultiline");
     method(_javaPart, multiline.has_value() ? jni::JBoolean::valueOf(multiline.value()) : nullptr);
   }
+  std::optional<std::string> JHybridNitroTextInputViewSpec::getPasswordRules() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getPasswordRules");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+  }
+  void JHybridNitroTextInputViewSpec::setPasswordRules(const std::optional<std::string>& passwordRules) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* passwordRules */)>("setPasswordRules");
+    method(_javaPart, passwordRules.has_value() ? jni::make_jstring(passwordRules.value()) : nullptr);
+  }
   std::optional<std::string> JHybridNitroTextInputViewSpec::getPlaceholder() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getPlaceholder");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.hpp
@@ -83,6 +83,8 @@ namespace margelo::nitro::nitrotextinput {
     void setMaxLength(std::optional<double> maxLength) override;
     std::optional<bool> getMultiline() override;
     void setMultiline(std::optional<bool> multiline) override;
+    std::optional<std::string> getPasswordRules() override;
+    void setPasswordRules(const std::optional<std::string>& passwordRules) override;
     std::optional<std::string> getPlaceholder() override;
     void setPlaceholder(const std::optional<std::string>& placeholder) override;
     std::optional<TextAlign> getTextAlign() override;

--- a/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridNitroTextInputViewStateUpdater.cpp
@@ -104,6 +104,10 @@ void JHybridNitroTextInputViewStateUpdater::updateViewProps(jni::alias_ref<jni::
     view->setMultiline(props.multiline.value);
     // TODO: Set isDirty = false
   }
+  if (props.passwordRules.isDirty) {
+    view->setPasswordRules(props.passwordRules.value);
+    // TODO: Set isDirty = false
+  }
   if (props.placeholder.isDirty) {
     view->setPlaceholder(props.placeholder.value);
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrotextinput/HybridNitroTextInputViewSpec.kt
@@ -144,6 +144,12 @@ abstract class HybridNitroTextInputViewSpec: HybridView() {
   @get:Keep
   @set:DoNotStrip
   @set:Keep
+  abstract var passwordRules: String?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
   abstract var placeholder: String?
   
   @get:DoNotStrip

--- a/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroTextInputViewSpecSwift.hpp
@@ -201,6 +201,13 @@ namespace margelo::nitro::nitrotextinput {
     inline void setMultiline(std::optional<bool> multiline) noexcept override {
       _swiftPart.setMultiline(multiline);
     }
+    inline std::optional<std::string> getPasswordRules() noexcept override {
+      auto __result = _swiftPart.getPasswordRules();
+      return __result;
+    }
+    inline void setPasswordRules(const std::optional<std::string>& passwordRules) noexcept override {
+      _swiftPart.setPasswordRules(passwordRules);
+    }
     inline std::optional<std::string> getPlaceholder() noexcept override {
       auto __result = _swiftPart.getPlaceholder();
       return __result;

--- a/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridNitroTextInputViewComponent.mm
@@ -156,6 +156,11 @@ using namespace margelo::nitro::nitrotextinput::views;
     swiftPart.setMultiline(newViewProps.multiline.value);
     newViewProps.multiline.isDirty = false;
   }
+  // passwordRules: optional
+  if (newViewProps.passwordRules.isDirty) {
+    swiftPart.setPasswordRules(newViewProps.passwordRules.value);
+    newViewProps.passwordRules.isDirty = false;
+  }
   // placeholder: optional
   if (newViewProps.placeholder.isDirty) {
     swiftPart.setPlaceholder(newViewProps.placeholder.value);

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec.swift
@@ -28,6 +28,7 @@ public protocol HybridNitroTextInputViewSpec_protocol: HybridObject, HybridView 
   var maxFontSizeMultiplier: Double? { get set }
   var maxLength: Double? { get set }
   var multiline: Bool? { get set }
+  var passwordRules: String? { get set }
   var placeholder: String? { get set }
   var textAlign: TextAlign? { get set }
   var placeholderTextColor: ProcessedColor? { get set }

--- a/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroTextInputViewSpec_cxx.swift
@@ -401,6 +401,29 @@ open class HybridNitroTextInputViewSpec_cxx {
     }
   }
   
+  public final var passwordRules: bridge.std__optional_std__string_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = self.__implementation.passwordRules {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.passwordRules = { () -> String? in
+        if let __unwrapped = newValue.value {
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
+  
   public final var placeholder: bridge.std__optional_std__string_ {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.cpp
@@ -48,6 +48,8 @@ namespace margelo::nitro::nitrotextinput {
       prototype.registerHybridSetter("maxLength", &HybridNitroTextInputViewSpec::setMaxLength);
       prototype.registerHybridGetter("multiline", &HybridNitroTextInputViewSpec::getMultiline);
       prototype.registerHybridSetter("multiline", &HybridNitroTextInputViewSpec::setMultiline);
+      prototype.registerHybridGetter("passwordRules", &HybridNitroTextInputViewSpec::getPasswordRules);
+      prototype.registerHybridSetter("passwordRules", &HybridNitroTextInputViewSpec::setPasswordRules);
       prototype.registerHybridGetter("placeholder", &HybridNitroTextInputViewSpec::getPlaceholder);
       prototype.registerHybridSetter("placeholder", &HybridNitroTextInputViewSpec::setPlaceholder);
       prototype.registerHybridGetter("textAlign", &HybridNitroTextInputViewSpec::getTextAlign);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -107,6 +107,8 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setMaxLength(std::optional<double> maxLength) = 0;
       virtual std::optional<bool> getMultiline() = 0;
       virtual void setMultiline(std::optional<bool> multiline) = 0;
+      virtual std::optional<std::string> getPasswordRules() = 0;
+      virtual void setPasswordRules(const std::optional<std::string>& passwordRules) = 0;
       virtual std::optional<std::string> getPlaceholder() = 0;
       virtual void setPlaceholder(const std::optional<std::string>& placeholder) = 0;
       virtual std::optional<TextAlign> getTextAlign() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.cpp
@@ -195,6 +195,16 @@ namespace margelo::nitro::nitrotextinput::views {
         throw std::runtime_error(std::string("NitroTextInputView.multiline: ") + exc.what());
       }
     }()),
+    passwordRules([&]() -> CachedProp<std::optional<std::string>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("passwordRules", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.passwordRules;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::string>>::fromRawValue(*runtime, value, sourceProps.passwordRules);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroTextInputView.passwordRules: ") + exc.what());
+      }
+    }()),
     placeholder([&]() -> CachedProp<std::optional<std::string>> {
       try {
         const react::RawValue* rawValue = rawProps.at("placeholder", nullptr, nullptr);
@@ -445,6 +455,7 @@ namespace margelo::nitro::nitrotextinput::views {
     maxFontSizeMultiplier(other.maxFontSizeMultiplier),
     maxLength(other.maxLength),
     multiline(other.multiline),
+    passwordRules(other.passwordRules),
     placeholder(other.placeholder),
     textAlign(other.textAlign),
     placeholderTextColor(other.placeholderTextColor),
@@ -488,6 +499,7 @@ namespace margelo::nitro::nitrotextinput::views {
       case hashString("maxFontSizeMultiplier"): return true;
       case hashString("maxLength"): return true;
       case hashString("multiline"): return true;
+      case hashString("passwordRules"): return true;
       case hashString("placeholder"): return true;
       case hashString("textAlign"): return true;
       case hashString("placeholderTextColor"): return true;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -41,6 +41,8 @@
 #include <optional>
 #include <string>
 #include <optional>
+#include <string>
+#include <optional>
 #include "TextAlign.hpp"
 #include <optional>
 #include <string>
@@ -127,6 +129,7 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<double>> maxFontSizeMultiplier;
     CachedProp<std::optional<double>> maxLength;
     CachedProp<std::optional<bool>> multiline;
+    CachedProp<std::optional<std::string>> passwordRules;
     CachedProp<std::optional<std::string>> placeholder;
     CachedProp<std::optional<TextAlign>> textAlign;
     CachedProp<std::optional<std::variant<std::string, double>>> placeholderTextColor;

--- a/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
+++ b/nitrogen/generated/shared/json/NitroTextInputViewConfig.json
@@ -21,6 +21,7 @@
     "maxFontSizeMultiplier": true,
     "maxLength": true,
     "multiline": true,
+    "passwordRules": true,
     "placeholder": true,
     "textAlign": true,
     "placeholderTextColor": true,

--- a/src/specs/text-input-view.nitro.ts
+++ b/src/specs/text-input-view.nitro.ts
@@ -122,6 +122,7 @@ export interface NitroTextInputViewProps extends HybridViewProps {
   maxFontSizeMultiplier?: MaxFontMultiplier
   maxLength?: number
   multiline?: boolean
+  passwordRules?: string | null
   placeholder?: string
   textAlign?: TextAlign
   placeholderTextColor?: ProcessedColor


### PR DESCRIPTION
Introduce `passwordRules` property for NitroTextInput, enabling custom password validation rules on iOS. Clean up example code by removing unnecessary properties. Fix the UITextInputPasswordRules initializer label for consistency.