### PR TITLE
refactor: remove duplicate autoComplete methods from HybridNitroTextInput

### DIFF
--- a/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroTextInputViewSpec.cpp
@@ -105,15 +105,6 @@ namespace margelo::nitro::nitrotextinput {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JAutoComplete> /* autoComplete */)>("setAutoComplete");
     method(_javaPart, autoComplete.has_value() ? JAutoComplete::fromCpp(autoComplete.value()) : nullptr);
   }
-  std::optional<AutoComplete> JHybridNitroTextInputViewSpec::getAutoComplete() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JAutoComplete>()>("getAutoComplete");
-    auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
-  }
-  void JHybridNitroTextInputViewSpec::setAutoComplete(std::optional<AutoComplete> autoComplete) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JAutoComplete> /* autoComplete */)>("setAutoComplete");
-    method(_javaPart, autoComplete.has_value() ? JAutoComplete::fromCpp(autoComplete.value()) : nullptr);
-  }
   std::optional<bool> JHybridNitroTextInputViewSpec::getAutoCorrect() {
     static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getAutoCorrect");
     auto __result = method(_javaPart);

--- a/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroTextInputViewSpec.hpp
@@ -79,8 +79,6 @@ namespace margelo::nitro::nitrotextinput {
       virtual void setAutoCapitalize(std::optional<AutoCapitalize> autoCapitalize) = 0;
       virtual std::optional<AutoComplete> getAutoComplete() = 0;
       virtual void setAutoComplete(std::optional<AutoComplete> autoComplete) = 0;
-      virtual std::optional<AutoComplete> getAutoComplete() = 0;
-      virtual void setAutoComplete(std::optional<AutoComplete> autoComplete) = 0;
       virtual std::optional<bool> getAutoCorrect() = 0;
       virtual void setAutoCorrect(std::optional<bool> autoCorrect) = 0;
       virtual std::optional<bool> getAutoFocus() = 0;

--- a/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
+++ b/nitrogen/generated/shared/c++/views/HybridNitroTextInputViewComponent.hpp
@@ -115,7 +115,6 @@ namespace margelo::nitro::nitrotextinput::views {
     CachedProp<std::optional<bool>> allowFontScaling;
     CachedProp<std::optional<AutoCapitalize>> autoCapitalize;
     CachedProp<std::optional<AutoComplete>> autoComplete;
-    CachedProp<std::optional<AutoComplete>> autoComplete;
     CachedProp<std::optional<bool>> autoCorrect;
     CachedProp<std::optional<bool>> autoFocus;
     CachedProp<std::optional<bool>> caretHidden;

--- a/package.json
+++ b/package.json
@@ -1,128 +1,128 @@
 {
-	"name": "react-native-nitro-text-input",
-	"version": "1.0.0-beta.1",
-	"description": "nitro-text-input",
-	"main": "lib/index",
-	"module": "lib/index",
-	"types": "lib/index.d.ts",
-	"react-native": "src/index",
-	"source": "src/index",
-	"files": [
-		"src",
-		"react-native.config.js",
-		"lib",
-		"nitrogen",
-		"android/build.gradle",
-		"android/gradle.properties",
-		"android/fix-prefab.gradle",
-		"android/CMakeLists.txt",
-		"android/src",
-		"ios/**/*.h",
-		"ios/**/*.m",
-		"ios/**/*.mm",
-		"ios/**/*.cpp",
-		"ios/**/*.swift",
-		"app.plugin.js",
-		"nitro.json",
-		"*.podspec",
-		"README.md"
-	],
-	"scripts": {
-		"postinstall": "tsc || exit 0;",
-		"typecheck": "tsc --noEmit",
-		"clean": "rm -rf android/build node_modules/**/android/build lib",
-		"lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
-		"lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
-		"typescript": "tsc",
-		"specs": "typescript && nitro-codegen --logLevel=\"debug\"",
-		"prepare": "husky",
-		"release": "semantic-release"
-	},
-	"keywords": [
-		"react-native",
-		"nitro"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/Ucekay/react-native-nitro-text-input.git"
-	},
-	"author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/Ucekay/react-native-nitro-text-input/issues"
-	},
-	"homepage": "https://github.com/Ucekay/react-native-nitro-text-input#readme",
-	"private": false,
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.2.0",
-		"@commitlint/cli": "^19.8.1",
-		"@commitlint/config-conventional": "^19.8.1",
-		"@react-native/eslint-config": "0.81.0",
-		"@semantic-release/changelog": "^6.0.3",
-		"@semantic-release/git": "^10.0.1",
-		"@semantic-release/github": "^11.0.4",
-		"@semantic-release/npm": "^12.0.2",
-		"@types/jest": "^29.5.14",
-		"@types/react": "^19.1.11",
-		"conventional-changelog-conventionalcommits": "^9.1.0",
-		"eslint": "^8.57.1",
-		"eslint-config-prettier": "^9.1.2",
-		"eslint-plugin-prettier": "^5.5.4",
-		"husky": "^9.1.7",
-		"nitro-codegen": "^0.28.1",
-		"prettier": "^3.6.2",
-		"react": "19.1.0",
-		"react-native": "0.81.0",
-		"react-native-nitro-modules": "^0.28.1",
-		"semantic-release": "^24.2.7",
-		"typescript": "^5.9.2"
-	},
-	"peerDependencies": {
-		"react": "*",
-		"react-native": "*",
-		"react-native-nitro-modules": "*"
-	},
-	"eslintConfig": {
-		"root": true,
-		"extends": [
-			"@react-native",
-			"prettier"
-		],
-		"plugins": [
-			"prettier"
-		],
-		"rules": {
-			"prettier/prettier": [
-				"warn",
-				{
-					"quoteProps": "consistent",
-					"singleQuote": true,
-					"tabWidth": 2,
-					"trailingComma": "es5",
-					"useTabs": false
-				}
-			]
-		}
-	},
-	"eslintIgnore": [
-		"node_modules/",
-		"lib/"
-	],
-	"prettier": {
-		"quoteProps": "consistent",
-		"singleQuote": true,
-		"tabWidth": 2,
-		"trailingComma": "es5",
-		"useTabs": false,
-		"semi": false
-	},
-	"patchedDependencies": {
-		"react-native@0.81.0": "patches/react-native@0.81.0.patch",
-		"react-native-nitro-modules@0.28.0": "patches/react-native-nitro-modules@0.28.0.patch",
-		"react-native-nitro-modules@0.28.1": "patches/react-native-nitro-modules@0.28.1.patch"
-	}
+  "name": "react-native-nitro-text-input",
+  "version": "1.0.0-next.36",
+  "description": "nitro-text-input",
+  "main": "lib/index",
+  "module": "lib/index",
+  "types": "lib/index.d.ts",
+  "react-native": "src/index",
+  "source": "src/index",
+  "files": [
+    "src",
+    "react-native.config.js",
+    "lib",
+    "nitrogen",
+    "android/build.gradle",
+    "android/gradle.properties",
+    "android/fix-prefab.gradle",
+    "android/CMakeLists.txt",
+    "android/src",
+    "ios/**/*.h",
+    "ios/**/*.m",
+    "ios/**/*.mm",
+    "ios/**/*.cpp",
+    "ios/**/*.swift",
+    "app.plugin.js",
+    "nitro.json",
+    "*.podspec",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "tsc || exit 0;",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf android/build node_modules/**/android/build lib",
+    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
+    "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",
+    "typescript": "tsc",
+    "specs": "typescript && nitro-codegen --logLevel=\"debug\"",
+    "prepare": "husky",
+    "release": "semantic-release"
+  },
+  "keywords": [
+    "react-native",
+    "nitro"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ucekay/react-native-nitro-text-input.git"
+  },
+  "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Ucekay/react-native-nitro-text-input/issues"
+  },
+  "homepage": "https://github.com/Ucekay/react-native-nitro-text-input#readme",
+  "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.2.0",
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
+    "@react-native/eslint-config": "0.81.0",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^11.0.4",
+    "@semantic-release/npm": "^12.0.2",
+    "@types/jest": "^29.5.14",
+    "@types/react": "^19.1.11",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.2",
+    "eslint-plugin-prettier": "^5.5.4",
+    "husky": "^9.1.7",
+    "nitro-codegen": "^0.28.1",
+    "prettier": "^3.6.2",
+    "react": "19.1.0",
+    "react-native": "0.81.0",
+    "react-native-nitro-modules": "^0.28.1",
+    "semantic-release": "^24.2.7",
+    "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*",
+    "react-native-nitro-modules": "*"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "@react-native",
+      "prettier"
+    ],
+    "plugins": [
+      "prettier"
+    ],
+    "rules": {
+      "prettier/prettier": [
+        "warn",
+        {
+          "quoteProps": "consistent",
+          "singleQuote": true,
+          "tabWidth": 2,
+          "trailingComma": "es5",
+          "useTabs": false
+        }
+      ]
+    }
+  },
+  "eslintIgnore": [
+    "node_modules/",
+    "lib/"
+  ],
+  "prettier": {
+    "quoteProps": "consistent",
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "es5",
+    "useTabs": false,
+    "semi": false
+  },
+  "patchedDependencies": {
+    "react-native@0.81.0": "patches/react-native@0.81.0.patch",
+    "react-native-nitro-modules@0.28.0": "patches/react-native-nitro-modules@0.28.0.patch",
+    "react-native-nitro-modules@0.28.1": "patches/react-native-nitro-modules@0.28.1.patch"
+  }
 }


### PR DESCRIPTION
Clean up the interface by eliminating redundant declarations for
getAutoComplete and setAutoComplete methods in HybridNitroTextInputViewSpec.